### PR TITLE
Update _document.tsx: Fix broken file favicon path

### DIFF
--- a/examples/nextjs-with-typescript/pages/_document.tsx
+++ b/examples/nextjs-with-typescript/pages/_document.tsx
@@ -11,7 +11,7 @@ export default class MyDocument extends Document {
         <Head>
           {/* PWA primary color */}
           <meta name="theme-color" content={theme.palette.primary.main} />
-          <link rel="shortcut icon" href="/static/favicon.ico" />
+          <link rel="shortcut icon" href="favicon.ico" />
           <link
             rel="stylesheet"
             href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"


### PR DESCRIPTION
Update path to favicon.ico

- Next is not serving static files from the "/static" folder anymore. Instead, all files inside the "public"
are accessible in pages.
- Replace path "/static/favicon.ico" with "favicon.ico"

Signed-off-by: Vegan Cat <mmostafavi247@gmail.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
